### PR TITLE
Fixing a few broken links on the homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -75,7 +75,7 @@ c<!DOCTYPE html>
       <div class="intro-info">
         <h2>Plasma Group</h2>
         <div>
-          <a href="https://github.com/plasma-group/plasma-chain-operator" class="btn-learn">launch your own plasma chain </a>
+          <a href="https://github.com/plasma-group/pigi/tree/master/packages/core" class="btn-learn">launch your own plasma chain </a>
           <a href="https://github.com/plasma-group/plasma-client" class="btn-learn">send your first plasma transaction</a>
         </div>
         <p>Join the network of plasma chains.</p>


### PR DESCRIPTION
Given the switch to a mono-repo a few links on the landing page are broken...I updated the first one to reference `core`, although could see which package the `plasma-client` has been moved to.